### PR TITLE
feat: add category filter endpoint

### DIFF
--- a/app/articles.py
+++ b/app/articles.py
@@ -9,7 +9,7 @@ from flask_cors import cross_origin
 @cross_origin()
 def getAvailableArticles():
     query = """
-    SELECT Title, DatePublished, DOI, URL FROM Articles
+    SELECT Title, DatePublished AS YearPublished, DOI, URL FROM Articles
     """
 
     conn = mysql.connect()

--- a/app/articles.py
+++ b/app/articles.py
@@ -9,7 +9,7 @@ from flask_cors import cross_origin
 @cross_origin()
 def getAvailableArticles():
     query = """
-    SELECT Title, DatePublished AS YearPublished, DOI, URL FROM Articles
+    SELECT Title, YearPublished, DOI, URL FROM Articles
     """
 
     conn = mysql.connect()

--- a/app/articles.py
+++ b/app/articles.py
@@ -5,7 +5,7 @@ from flask import jsonify, request
 from flask_cors import cross_origin
 
 
-@app.route("/articles")
+@app.route("/api/articles")
 @cross_origin()
 def getAvailableArticles():
     query = """

--- a/app/category.py
+++ b/app/category.py
@@ -9,10 +9,7 @@ from flask_cors import cross_origin
 @cross_origin()
 def getAvailableCategory():
     query_parameters = request.args
-    print(query_parameters)
     category = query_parameters.get('categoryName')
-    #print(category)
-    #print('Printing query')
     
     query = """
     SELECT A.Title, A.URL, A.DOI, A.YearPublished, J.JournalName, C.CategoryName FROM Articles 
@@ -23,7 +20,7 @@ def getAvailableCategory():
     """.format(
         category
     )
-    #print(query)
+    
     conn = mysql.connect()
     cursor = conn.cursor(pymysql.cursors.DictCursor)
     cursor.execute(query)

--- a/app/category.py
+++ b/app/category.py
@@ -1,0 +1,33 @@
+import pymysql
+from app import app
+from db import mysql
+from flask import jsonify, request
+from flask_cors import cross_origin
+
+
+@app.route("/api/category")
+@cross_origin()
+def getAvailableCategory():
+    query_parameters = request.args
+    print(query_parameters)
+    category = query_parameters.get('CategoryName')
+    print(category)
+    print('Printing query')
+    
+    query = """
+    SELECT A.Title, A.URL, A.DOI, A.YearPublished, J.JournalName, C.CategoryName FROM Articles AS A, Journals AS J, Category AS C
+    WHERE C.CategoryName='{0}'
+    """.format(
+        category
+    )
+    print(query)
+    conn = mysql.connect()
+    cursor = conn.cursor(pymysql.cursors.DictCursor)
+    cursor.execute(query)
+    results = cursor.fetchall()
+
+    resp = jsonify(results)
+
+    resp.status_code = 200
+
+    return resp

--- a/app/category.py
+++ b/app/category.py
@@ -10,17 +10,20 @@ from flask_cors import cross_origin
 def getAvailableCategory():
     query_parameters = request.args
     print(query_parameters)
-    category = query_parameters.get('CategoryName')
-    print(category)
-    print('Printing query')
+    category = query_parameters.get('categoryName')
+    #print(category)
+    #print('Printing query')
     
     query = """
-    SELECT A.Title, A.URL, A.DOI, A.YearPublished, J.JournalName, C.CategoryName FROM Articles AS A, Journals AS J, Category AS C
-    WHERE C.CategoryName='{0}'
+    SELECT A.Title, A.URL, A.DOI, A.YearPublished, J.JournalName, C.CategoryName FROM Articles 
+    AS A, Journals AS J, Category AS C 
+    WHERE  A.JournalID = J.JournalID AND A.CategoryID = C.CategoryID AND 
+    C.CategoryName='{0}'
+    ORDER BY A.YearPublished DESC;
     """.format(
         category
     )
-    print(query)
+    #print(query)
     conn = mysql.connect()
     cursor = conn.cursor(pymysql.cursors.DictCursor)
     cursor.execute(query)

--- a/app/rest.py
+++ b/app/rest.py
@@ -4,3 +4,4 @@ if __name__ == "__main__":
     app.run(debug=True, host="0.0.0.0")
 
 import articles
+import category


### PR DESCRIPTION
# Pull Request

## Scope
https://dev.azure.com/CPerrie/Aarons%20Kit%20-%20Information%20Storage/_workitems/edit/52
## Work Done
1. Change the articles endpoint to '/api/articles'
2. Created a category.py file which is a endpoint for articles to be filtered by category.
## Steps to Test
1. Run doker compose up
2. In a web browser, type 'http://localhost:5000/api/category?categoryName=Economics'
3. The result is the article information represented in JSON format.
<img width="515" alt="filter_by_category" src="https://user-images.githubusercontent.com/68713894/134673270-cdb47a61-caee-4c8d-9b3c-fe39ada43201.png">
