### PR TITLE
feat: search by article title

### DIFF
--- a/app/articles.py
+++ b/app/articles.py
@@ -22,3 +22,31 @@ def getAvailableArticles():
     resp.status_code = 200
 
     return resp
+
+@app.route("/api/articles/search")
+@cross_origin()
+def getArticlebyTitleSearch():
+    query_parameters = request.args
+    search = query_parameters.get('title')
+    
+    query = """
+    SELECT Title,
+    YearPublished,
+    DOI,
+    URL
+    FROM Articles
+    WHERE Title LIKE '%{}%'
+    """.format(
+        search
+    )
+    
+    conn = mysql.connect()
+    cursor = conn.cursor(pymysql.cursors.DictCursor)
+    cursor.execute(query)
+    results = cursor.fetchall()
+
+    resp = jsonify(results)
+
+    resp.status_code = 200
+
+    return resp

--- a/app/journal.py
+++ b/app/journal.py
@@ -60,8 +60,8 @@ def getSpecificArticlesfromJournals():
     AS J_C_A
     INNER JOIN Authors
     ON J_C_A.ArticleID = Authors.AuthorID
-    WHERE JournalName = '{0}'
-    ORDER BY YearPublished DESC;
+    WHERE JournalName LIKE '%{}%'
+    ORDER BY YearPublished DESC
     """.format(
         journal
     )


### PR DESCRIPTION
# Pull Request

-  Search functionality for article's title.
-  Change `getSpecificArticlesfromJournals` function in journal.py

## Scope
https://dev.azure.com/CPerrie/Aarons%20Kit%20-%20Information%20Storage/_workitems/edit/52

## Work Done
In the `articles.py` script, I have added a search functionality, specifically one can search for a title.
In the `journal.py` script, instead of filtering a journal, one can search phrases and the output is articles form journals that resemble what was initially searched (see the examples below).

## Steps to Test
1. Launch the `search_by_article_title` branch locally.
2. Run `docker compose up`
3.  In a web browser, run `http://localhost:5000/api/articles/search?title=mi` to search article titles that have `mi` phrase.
4. In a web browser, run `http://localhost:5000/api/journals?journalName=American` to search for articles in a journal, where the  key phrase in searching the journal is `American`
<img width="519" alt="American" src="https://user-images.githubusercontent.com/68713894/135147675-569f4d7f-7b48-4aa2-a156-53be65761961.png">
<img width="500" alt="mi" src="https://user-images.githubusercontent.com/68713894/135147682-61521352-9baa-4f79-90b1-01e388746693.png">
.