### PR TITLE
feat: create 'serch by author' endpoint

### DIFF
--- a/app/authors.py
+++ b/app/authors.py
@@ -1,0 +1,44 @@
+import pymysql
+from app import app
+from db import mysql
+from flask import jsonify, request
+from flask_cors import cross_origin
+
+@app.route("/api/authors/search")
+@cross_origin()
+def getArticlebyAuthorSearch():
+    query_parameters = request.args
+    search = query_parameters.get('AuthorSurname')
+    
+    query = """
+    SELECT 
+    A.URL,
+    A.Title, 
+    A.YearPublished, 
+    A.DOI, 
+    P.AuthorSurname 
+    FROM
+    Articles AS A,
+    (SELECT W.ArticleID, 
+    AuthS.AuthorSurname 
+    FROM Writes AS W, 
+	    (SELECT AuthorID, 
+        AuthorSurname FROM Authors 
+        WHERE AuthorSurname LIKE '%{}%')
+    AS AuthS WHERE W.AuthorID = AuthS.AuthorID
+    )
+    AS P WHERE P.ArticleID = A.ArticleID;
+    """.format(
+        search
+    )
+    
+    conn = mysql.connect()
+    cursor = conn.cursor(pymysql.cursors.DictCursor)
+    cursor.execute(query)
+    results = cursor.fetchall()
+
+    resp = jsonify(results)
+
+    resp.status_code = 200
+
+    return resp

--- a/app/rest.py
+++ b/app/rest.py
@@ -6,3 +6,4 @@ if __name__ == "__main__":
 import articles
 import category
 import journal
+import authors


### PR DESCRIPTION
# Pull Request
Search for articles by author surname.
## Scope
https://dev.azure.com/CPerrie/Aarons%20Kit%20-%20Information%20Storage/_workitems/edit/52
## Work Done
In the `authors.py` script, I created a function that lets a user search for articles by typing the name of the author.
## Steps to Test
1. Open the `search_by_author` branch locally.
2. Run `docker compose up`
3. In a web browser, enter the following URL: `http://localhost:5000/api/authors/search?AuthorSurname=ll`

<img width="485" alt="search_by_athour_surname" src="https://user-images.githubusercontent.com/68713894/135279702-88294967-c0c1-497f-ba63-6bd38e3140c6.png">

