### PR TITLE
feat: create doi endpoint

### DIFF
--- a/app/DOI.py
+++ b/app/DOI.py
@@ -1,0 +1,31 @@
+import pymysql
+from app import app
+from db import mysql
+from flask import jsonify, request
+from flask_cors import cross_origin
+
+@app.route("/api/articles/doi")
+@cross_origin()
+def checkArticlebyDOI():
+    query_parameters = request.args
+    search = query_parameters.get('checkdoi')
+
+    query = """
+    SELECT DOI
+    FROM Articles
+    WHERE DOI ="{}";
+    """.format(
+        search
+    )
+    
+    conn = mysql.connect()
+    cursor = conn.cursor(pymysql.cursors.DictCursor)
+    cursor.execute(query)
+    results = cursor.fetchall()
+
+    resp = jsonify(results)
+
+    resp.status_code = 200
+
+    return resp
+

--- a/app/rest.py
+++ b/app/rest.py
@@ -7,3 +7,4 @@ import articles
 import category
 import journal
 import authors
+import DOI


### PR DESCRIPTION
# Pull Request
Create an endpoint that searches the database of an article by inputting a DOI.
## Scope
https://dev.azure.com/CPerrie/Aarons%20Kit%20-%20Information%20Storage/_workitems/edit/71
## Work Done
Create a function that requires the user to input the DOI of an article, and returns as an output the DOI (indicating the article is in the system) and an empty list if the article is not in the database. 
## Steps to Test
1. Open the `add_doi_endpoint` on a local text editor.
2. Run `docker compose up`
3. In a web browser, type the following `http://localhost:5000/api/articles/doi?checkdoi=10.2307/41803204`
4. It should return a DOI, indicating that article is in the database.
<img width="389" alt="checkdoi" src="https://user-images.githubusercontent.com/68713894/136772828-96012f5e-5a42-4e2c-b371-96980ed3766f.png">

